### PR TITLE
Change matplotlib version from 1.5.1 to 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env/
 .ipynb_checkpoints/
+.idea/
+.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.10.4
-matplotlib==1.5.1
+matplotlib==2.0.0
 scipy==0.17.0
 pandas==0.17.1
 seaborn==0.7.0


### PR DESCRIPTION
We need interactive graphics in the pipeline container. For that, python3-tk and matplotlib are needed. In the pydev container is where these two are stored, and graphics doesn't work with the older version of matplotlib. I have tested it in a pydev container. If you merge this, would you rebuild the downstream containers so I can test ninai/pipeline? Thanks.