### PR TITLE
Add cryptography dependency for base image (plugin support)

### DIFF
--- a/dist/ubuntu/requirements.txt
+++ b/dist/ubuntu/requirements.txt
@@ -5,3 +5,4 @@ pandas
 seaborn
 ipython
 jupyter
+cryptography


### PR DESCRIPTION
Fix https://github.com/datajoint/datajoint-python/issues/788